### PR TITLE
NetworkObject implementation

### DIFF
--- a/NetSync/NetSync.sln
+++ b/NetSync/NetSync.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetSync", "NetSync\NetSync.csproj", "{3BF7736C-7346-4041-A756-E88A084DFE04}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSync", "NetSync\NetSync.csproj", "{3BF7736C-7346-4041-A756-E88A084DFE04}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/NetSync/NetSync/Packet.cs
+++ b/NetSync/NetSync/Packet.cs
@@ -15,6 +15,7 @@ namespace NetSync
         /// </summary>
         public Packet()
         {
+            Console.WriteLine("without data");
             _buffer = new List<byte>();
         }
 
@@ -24,6 +25,7 @@ namespace NetSync
         /// <param name="receivedData">Received data</param>
         public Packet(byte[] receivedData)
         {
+            Console.WriteLine("with data");
             _readBuffer = receivedData;
         }
 
@@ -44,6 +46,10 @@ namespace NetSync
         /// <param name="data">Byte to write</param>
         public void WriteByte(byte data)
             => _buffer.Add(data);
+
+        //TODO: WRITE A SUMMARY
+        public void WriteByteArray(byte[] data) 
+            => _buffer.AddRange(data);
 
         /// <summary>
         /// Inserts byte into specified index of the buffer.


### PR DESCRIPTION
Implemented a networked object implementation. When server calls CreateNetworkObject method from NetworkServer, the object that was given as parameter gets created on all clients.

Unfinished implementation: Late joiners will not get the previously created classes.
Note: Late comer synchronization should be optional. Server may want to instantiate that class for only the currently connected clients rather than also sync it to the late comers. Make late comer sync optional.