### PR TITLE
Tight integration of Channels into the library.

### DIFF
--- a/NetSync/NetSync/Packet.cs
+++ b/NetSync/NetSync/Packet.cs
@@ -15,7 +15,6 @@ namespace NetSync
         /// </summary>
         public Packet()
         {
-            Console.WriteLine("without data");
             _buffer = new List<byte>();
         }
 
@@ -25,7 +24,6 @@ namespace NetSync
         /// <param name="receivedData">Received data</param>
         public Packet(byte[] receivedData)
         {
-            Console.WriteLine("with data");
             _readBuffer = receivedData;
         }
 
@@ -47,8 +45,7 @@ namespace NetSync
         public void WriteByte(byte data)
             => _buffer.Add(data);
 
-        //TODO: WRITE A SUMMARY
-        public void WriteByteArray(byte[] data) 
+        public void WriteByteArray(byte[] data)
             => _buffer.AddRange(data);
 
         /// <summary>
@@ -155,7 +152,7 @@ namespace NetSync
         public void WriteString(string data)
         {
             _buffer.AddRange(BitConverter.GetBytes(data.Length));
-            _buffer.AddRange(Encoding.UTF8.GetBytes(data));
+            _buffer.AddRange(Encoding.ASCII.GetBytes(data));
         }
 
         /// <summary>
@@ -163,7 +160,7 @@ namespace NetSync
         /// </summary>
         /// <param name="data">Static string to write</param>
         public void WriteStaticString(string data)
-            => _buffer.AddRange(Encoding.UTF8.GetBytes(data));
+            => _buffer.AddRange(Encoding.ASCII.GetBytes(data));
 
         #endregion Write Methods
 
@@ -305,7 +302,7 @@ namespace NetSync
             int dataLength = ReadInteger();
             if (_readBuffer.Length >= _readPosition + dataLength)
             {
-                string returnData = Encoding.UTF8.GetString(_readBuffer, _readPosition, dataLength);
+                string returnData = Encoding.ASCII.GetString(_readBuffer, _readPosition, dataLength);
                 _readPosition += dataLength;
                 return returnData;
             }
@@ -318,7 +315,7 @@ namespace NetSync
             //If there are any bytes left to read in the buffer
             if (_readBuffer.Length >= _readPosition + stringLength)
             {
-                string returnData = Encoding.UTF8.GetString(_readBuffer, _readPosition, stringLength);
+                string returnData = Encoding.ASCII.GetString(_readBuffer, _readPosition, stringLength);
                 _readPosition += stringLength;
                 return returnData;
             }

--- a/NetSync/NetSync/PacketHeader.cs
+++ b/NetSync/NetSync/PacketHeader.cs
@@ -1,0 +1,14 @@
+﻿namespace NetSync
+{
+    public struct PacketHeader
+    {
+        public byte Channel;
+        public byte PacketId;
+
+        public PacketHeader(byte channel, byte packetId)
+        {
+            Channel = channel;
+            PacketId = packetId;
+        }
+    }
+}

--- a/NetSync/NetSync/Server/Connection.cs
+++ b/NetSync/NetSync/Server/Connection.cs
@@ -1,6 +1,4 @@
-﻿using NetSync.Transport;
-
-namespace NetSync.Server
+﻿namespace NetSync.Server
 {
     public class Connection
     {

--- a/NetSync/NetSync/Transport/SyncTcp/SyncTcp.cs
+++ b/NetSync/NetSync/Transport/SyncTcp/SyncTcp.cs
@@ -51,7 +51,6 @@ namespace NetSync.Transport.SyncTcp
             try
             {
                 int byteLength = _netStream.EndRead(result);
-                Console.WriteLine("I received something: " + byteLength);
                 if (byteLength <= 0)
                 {
                     ClientDisconnect();
@@ -60,21 +59,29 @@ namespace NetSync.Transport.SyncTcp
 
                 byte[] data = new byte[byteLength];
                 Array.Copy(_receiveBuffer, data, byteLength);
+
                 _netStream.BeginRead(_receiveBuffer, 0, _bufferSize, ReceiveCallback, null);
                 Packet packet = new Packet(data);
-                OnClientDataReceive(packet, 0);
+
+                byte channel = packet.ReadByte();
+                byte packetId = packet.ReadByte();
+                PacketHeader packetHeader = new PacketHeader(channel, packetId);
+                OnClientDataReceive(packet, packetHeader);
             }
             catch (Exception exception)
             {
                 ClientDisconnect();
-                throw new Exception($"Error while receiving data from server! {exception}");
+                OnClientErrorDetected("Error while receiving data from server: " + exception);
             }
         }
 
         public override void ClientDisconnect()
         {
             if (_tcpClient != null)
+            {
+                _tcpClient.Client?.Disconnect(true);
                 _tcpClient.Close();
+            }
 
             _tcpClient = null;
             _netStream = null;
@@ -82,11 +89,13 @@ namespace NetSync.Transport.SyncTcp
             OnClientDisconnect();
         }
 
-        public override void ClientSendData(Packet packet, byte channel)
+        public override void ClientSendData(Packet packet, PacketHeader packetHeader)
         {
             try
             {
                 if (_tcpClient == null) return;
+                packet.InsertByte(0, packetHeader.Channel);
+                packet.InsertByte(1, packetHeader.PacketId);
                 byte[] data = packet.GetByteArray();
 
                 _netStream.BeginWrite(data, 0, data.Length, null, null);
@@ -141,8 +150,10 @@ namespace NetSync.Transport.SyncTcp
             OnServerDisconnect(connection);
         }
 
-        public override void ServerSend(Connection connection, Packet packet, byte channel)
+        public override void ServerSend(Connection connection, Packet packet, PacketHeader packetHeader)
         {
+            packet.InsertByte(0, packetHeader.Channel);
+            packet.InsertByte(1, packetHeader.PacketId);
             _serverConnections[connection.ConnectionId].ServerSend(packet);
         }
 
@@ -196,10 +207,14 @@ namespace NetSync.Transport.SyncTcp
                     _netStream.BeginRead(_receiveBuffer, 0, _bufferSize, ServerReceiveCallback, null);
 
                     Packet packetReceived = new Packet(data);
-                    _syncTcp.OnServerDataReceive(_connection, packetReceived, 0);
+                    byte channel = packetReceived.ReadByte();
+                    byte packetId = packetReceived.ReadByte();
+                    PacketHeader packetHeader = new PacketHeader(channel, packetId);
+                    _syncTcp.OnServerDataReceive(_connection, packetReceived, packetHeader);
                 }
                 catch
                 {
+                    _syncTcp.OnServerErrorDetected($"Error while receiving data from client [{_connection.ConnectionId}]");
                     _connection.Disconnect();
                 }
             }
@@ -219,6 +234,7 @@ namespace NetSync.Transport.SyncTcp
 
             internal void Disconnect()
             {
+                _tcpClient.Client.Disconnect(true);
                 _tcpClient.Close();
                 _receiveBuffer = null;
                 _tcpClient = null;

--- a/NetSync/NetSync/Transport/TransportBase.cs
+++ b/NetSync/NetSync/Transport/TransportBase.cs
@@ -10,26 +10,32 @@ namespace NetSync.Transport
         public delegate void ClientConnected();
         public event ClientConnected OnClientConnected;
 
-        public delegate void ClientDataReceived(Packet packet, byte channel);
+        public delegate void ClientDataReceived(Packet packet, PacketHeader packetHeader);
         public event ClientDataReceived OnClientDataReceived;
 
         public delegate void ClientDisconnected();
         public event ClientDisconnected OnClientDisconnected;
 
+        public delegate void ClientError(string description);
+        public event ClientError OnClientError;
+
         public abstract void ClientConnect(NetworkClient client);
 
         public abstract void ClientDisconnect();
 
-        public abstract void ClientSendData(Packet packet, byte channel);
+        public abstract void ClientSendData(Packet packet, PacketHeader packetHeader);
 
         protected void OnClientConnect()
             => OnClientConnected?.Invoke();
 
-        protected void OnClientDataReceive(Packet packet, byte channel)
-            => OnClientDataReceived?.Invoke(packet, channel);
+        protected void OnClientDataReceive(Packet packet, PacketHeader packetHeader)
+            => OnClientDataReceived?.Invoke(packet, packetHeader);
 
         protected void OnClientDisconnect()
             => OnClientDisconnected?.Invoke();
+
+        protected void OnClientErrorDetected(string description)
+            => OnClientError?.Invoke(description);
 
         #endregion Client
 
@@ -41,20 +47,21 @@ namespace NetSync.Transport
         public delegate void ServerConnected(Connection connection);
         public event ServerConnected OnServerConnected;
 
-        public delegate void ServerDataReceived(Connection connection, Packet packet, byte channel);
+        public delegate void ServerDataReceived(Connection connection, Packet packet, PacketHeader packetHeader);
         public event ServerDataReceived OnServerDataReceived;
 
         public delegate void ServerDisconnected(Connection connection);
-
         public event ServerDisconnected OnServerDisconnected;
 
         public delegate void ServerStopped(NetworkServer server);
-
         public event ServerStopped OnServerStopped;
+
+        public delegate void ServerError(string description);
+        public event ServerError OnServerError;
 
         public abstract void ServerStart(NetworkServer server);
 
-        public abstract void ServerSend(Connection connection, Packet packet, byte channel);
+        public abstract void ServerSend(Connection connection, Packet packet, PacketHeader packetHeader);
 
         public abstract void ServerDisconnect(Connection connection);
 
@@ -66,14 +73,17 @@ namespace NetSync.Transport
         protected void OnServerConnect(Connection connection)
             => OnServerConnected?.Invoke(connection);
 
-        protected void OnServerDataReceive(Connection connection, Packet packet, byte channel)
-            => OnServerDataReceived?.Invoke(connection, packet, channel);
+        protected void OnServerDataReceive(Connection connection, Packet packet, PacketHeader packetHeader)
+            => OnServerDataReceived?.Invoke(connection, packet, packetHeader);
 
         protected void OnServerDisconnect(Connection connection)
             => OnServerDisconnected?.Invoke(connection);
 
         protected void OnServerStop(NetworkServer server)
             => OnServerStopped?.Invoke(server);
+
+        protected void OnServerErrorDetected(string description)
+            => OnServerError?.Invoke(description);
 
         #endregion Server
     }


### PR DESCRIPTION
In the old implementation Transports were free to create their own packet headers. This created a dynamic environment but also created chaos for different transport implementations. To overcome this issue now the entire library's packet headers are based on a struct called PacketHeader. Transports are forced to use them. They can still add on top of it as they wish but the base structure of the header is based on the struct I have created.

Within this new packet header we are currently using 2 different bytes. First one is channel and second one is packet id. Previously writing channels into the packet header were optional and was decided by the Transport you are using. We forced it's usage. To keep the header size same as before(2bytes), rather than using unsigned integer for packetId I decided to use a byte. With 255 channels and 255 different packet ids, amount of packet ids you can create is same as before(if you were not using channels) which is 65k different packet ids/message handlers.
<br>
<br>
### Other Minor Changes:
I also changed the current encoding from UTF-8 to ASCII. For some stupid reason UTF-8 is fucking up with the entire byte buffer if there is any special characters in it and as a result the buffer is getting corrupted. Only reason we are using UTF-8 is to prevent shits like this happening but instead it decides to corrupt my entire buffer. THANK YOU! Now instead we are using ASCII. At least you just get an un-identified indicator for the special character you are using. So if you were writing "ğğğ hello ğğğ world" what you would see is: "??? hello ??? world". I think this is better than having your entire buffer being corrupted don't you think?

I consider this as a temporary solution though.