### PR TITLE
Unity3D Compatible API Changes

### DIFF
--- a/NetSync/NetSync/Client/NetworkClient.cs
+++ b/NetSync/NetSync/Client/NetworkClient.cs
@@ -56,19 +56,18 @@ namespace NetSync.Client
         public void RegisterHandler(byte packetId, MessageHandle handler, byte channel = 1)
         {
             PacketHeader packetHeader = new PacketHeader(channel, packetId);
+            if(ReceiveHandlers.ContainsKey(packetHeader))
+                throw new Exception($"Handler is already registered: {handler.Method.Name}");
 
-            if (ReceiveHandlers.TryAdd(packetHeader, handler) == false)
-            {
-                throw new Exception($"Error while registering handle: {handler.Method.Name}");
-            }
+            ReceiveHandlers.Add(packetHeader, handler);
         }
 
         public void RemoveHandler(MessageHandle handler)
         {
-            foreach (var (key, value) in ReceiveHandlers)
+            foreach (var msgHandler in ReceiveHandlers)
             {
-                if (value.Method.Name == handler.Method.Name)
-                    ReceiveHandlers.Remove(key);
+                if (msgHandler.Value.Method.Name == handler.Method.Name)
+                    ReceiveHandlers.Remove(msgHandler.Key);
             }
         }
 
@@ -77,7 +76,6 @@ namespace NetSync.Client
         public void NetworkSend(byte packetId, Packet packet, byte channel = 1)
         {
             PacketHeader packetHeader = new PacketHeader(channel, packetId);
-            packet.InsertUnsignedShort(0, packetId);
             Transport.ClientSendData(packet, packetHeader);
         }
 
@@ -98,7 +96,7 @@ namespace NetSync.Client
 
         private void OnClientError(string description)
         {
-            Console.WriteLine("Client Error: " + description);
+            throw new Exception("Client Error: " + description);
         }
 
         #endregion Transport Events

--- a/NetSync/NetSync/Server/NetworkServer.cs
+++ b/NetSync/NetSync/Server/NetworkServer.cs
@@ -64,10 +64,10 @@ namespace NetSync.Server
         {
             PacketHeader packetHeader = new PacketHeader(channel, packetId);
 
-            if (ReceiveHandlers.TryAdd(packetHeader, handler) == false)
-            {
-                throw new Exception($"Error while registering handle: {handler.Method.Name}");
-            }
+            if(ReceiveHandlers.ContainsKey(packetHeader))
+                throw new Exception($"Handler is already registered: {handler.Method.Name}");
+
+            ReceiveHandlers.Add(packetHeader, handler);
         }
 
         public void RemoveHandler(MessageHandle handler)
@@ -143,7 +143,7 @@ namespace NetSync.Server
 
         private void OnServerError(string description)
         {
-            Console.WriteLine("Error: " + description);
+            throw new Exception("Error: " + description);
         }
 
         #endregion Transport Events

--- a/NetSync/NetSync/Transport/SyncTcp/SyncTcp.cs
+++ b/NetSync/NetSync/Transport/SyncTcp/SyncTcp.cs
@@ -212,9 +212,9 @@ namespace NetSync.Transport.SyncTcp
                     PacketHeader packetHeader = new PacketHeader(channel, packetId);
                     _syncTcp.OnServerDataReceive(_connection, packetReceived, packetHeader);
                 }
-                catch
+                catch (Exception exception)
                 {
-                    _syncTcp.OnServerErrorDetected($"Error while receiving data from client [{_connection.ConnectionId}]");
+                    _syncTcp.OnServerErrorDetected($"Error while receiving data from client [{_connection.ConnectionId}] : " + exception);
                     _connection.Disconnect();
                 }
             }


### PR DESCRIPTION
Unity uses an antique version of Mono which is dated all the way back to the ancient egyptians whom lay the foundations of the pyramids. Due do this reason, Unity does not support some sexy syntax sugars implemented in new .Net versions. I had to modify them :)

Related issue: #12 