### PR TITLE
General Improvements

### DIFF
--- a/NetSync/NetSync.UnitTests/ConnectionTests.cs
+++ b/NetSync/NetSync.UnitTests/ConnectionTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NetSync.Client;
+using NetSync.Server;
+using NetSync.Transport.AsyncTcp;
+using System.Threading;
+
+namespace NetSync.UnitTests
+{
+    [TestClass]
+    public class ConnectionTests
+    {
+        [TestMethod]
+        public void CanConnect_MultipleClientsConnecting_ConnectionEstablishes()
+        {
+            #region Server Initialization
+
+            //server
+            AsyncTcp serverTransport = new AsyncTcp();
+            NetworkServer server = new NetworkServer(2401, 5, 4095, serverTransport);
+            server.StartServer();
+
+            #endregion Server Initialization
+
+            Thread.Sleep(1000);
+
+            #region Clients Initialization
+
+            //client 1
+            AsyncTcp client1Transport = new AsyncTcp();
+            NetworkClient client1 = new NetworkClient("127.0.0.1", 2401, 4095, client1Transport);
+
+            //client 2
+            AsyncTcp client2Transport = new AsyncTcp();
+            NetworkClient client2 = new NetworkClient("127.0.0.1", 2401, 4095, client2Transport);
+
+            //client3
+            AsyncTcp client3Transport = new AsyncTcp();
+            NetworkClient client3 = new NetworkClient("127.0.0.1", 2401, 4095, client3Transport);
+
+            client1.StartClient();
+            client2.StartClient();
+            client3.StartClient();
+
+            #endregion Clients Initialization
+
+            Thread.Sleep(1000);
+
+            Assert.IsTrue(client1.IsActive() && client2.IsActive() && client3.IsActive());
+        }
+
+        [TestMethod]
+        public void CanDisconnect_DisconnectedWithoutCrashingServer()
+        {
+            #region Server Initialization
+
+            //server
+            AsyncTcp serverTransport = new AsyncTcp();
+            NetworkServer server = new NetworkServer(2402, 5, 4095, serverTransport);
+            server.StartServer();
+
+            #endregion Server Initialization
+
+            Thread.Sleep(1000);
+
+            #region Clients Initialization
+
+            //client 1
+            AsyncTcp client1Transport = new AsyncTcp();
+            NetworkClient client1 = new NetworkClient("127.0.0.1", 2402, 4095, client1Transport);
+
+            //client 2
+            AsyncTcp client2Transport = new AsyncTcp();
+            NetworkClient client2 = new NetworkClient("127.0.0.1", 2402, 4095, client2Transport);
+
+            //client3
+            AsyncTcp client3Transport = new AsyncTcp();
+            NetworkClient client3 = new NetworkClient("127.0.0.1", 2402, 4095, client3Transport);
+
+            client1.StartClient();
+            client2.StartClient();
+            client3.StartClient();
+
+            #endregion Clients Initialization
+
+            Thread.Sleep(1000);
+
+            client1.StopClient();
+
+            Thread.Sleep(1000);
+
+            Assert.IsTrue(!client1.IsActive() && server.IsServerActive());
+        }
+    }
+}

--- a/NetSync/NetSync.UnitTests/NetSync.UnitTests.csproj
+++ b/NetSync/NetSync.UnitTests/NetSync.UnitTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NetSync\NetSync.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NetSync/NetSync.UnitTests/PacketHandlerTests.cs
+++ b/NetSync/NetSync.UnitTests/PacketHandlerTests.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NetSync.Client;
+using NetSync.Server;
+using NetSync.Transport.AsyncTcp;
+using System.Threading;
+
+namespace NetSync.UnitTests
+{
+    public class NetworkObjectTestClass
+    {
+        public bool Created;
+
+        public NetworkObjectTestClass()
+        {
+            Created = true;
+        }
+    }
+
+    [TestClass]
+    public class PacketHandlerTests
+    {
+        [TestMethod]
+        public void SendPacket_BothSidesReceives()
+        {
+            bool serverReceivedPacket = false;
+            bool clientReceivedPacket = false;
+
+            #region Server Initialization
+
+            //server
+            AsyncTcp serverTransport = new AsyncTcp();
+            NetworkServer server = new NetworkServer(2403, 5, 4095, serverTransport);
+            server.StartServer();
+
+            server.RegisterHandler(0, (connection, packet) =>
+            {
+                string msg = packet.ReadString();
+                int msg2 = packet.ReadInteger();
+                float msg3 = packet.ReadFloat();
+
+                if (msg == "I Am Alive!" && msg2 == 12345 && msg3 == 123.456f)
+                    serverReceivedPacket = true;
+            });
+
+            #endregion Server Initialization
+
+            Thread.Sleep(1000);
+
+            #region Clients Initialization
+
+            //client 1
+            AsyncTcp client1Transport = new AsyncTcp();
+            NetworkClient client1 = new NetworkClient("127.0.0.1", 2403, 4095, client1Transport);
+
+            //client 2
+            AsyncTcp client2Transport = new AsyncTcp();
+            NetworkClient client2 = new NetworkClient("127.0.0.1", 2403, 4095, client2Transport);
+
+            //client3
+            AsyncTcp client3Transport = new AsyncTcp();
+            NetworkClient client3 = new NetworkClient("127.0.0.1", 2403, 4095, client3Transport);
+
+            client1.StartClient();
+            client2.StartClient();
+            client3.StartClient();
+
+            client1.RegisterHandler(0, packet =>
+            {
+                string msg = packet.ReadString();
+                int msg2 = packet.ReadInteger();
+                float msg3 = packet.ReadFloat();
+
+                if (msg == "I Am Alive!" && msg2 == 12345 && msg3 == 123.456f)
+                    clientReceivedPacket = true;
+            });
+
+            #endregion Clients Initialization
+
+            Thread.Sleep(1000);
+
+            #region Server Sending Data
+
+            Packet serverPacket = new Packet();
+            serverPacket.WriteString("I Am Alive!");
+            serverPacket.WriteInteger(12345);
+            serverPacket.WriteFloat(123.456f);
+
+            server.NetworkSendEveryone(0, serverPacket);
+
+            #endregion Server Sending Data
+
+            #region Client Sending Data
+
+            Packet clientPacket = new Packet();
+            clientPacket.WriteString("I Am Alive!");
+            clientPacket.WriteInteger(12345);
+            clientPacket.WriteFloat(123.456f);
+
+            client1.NetworkSend(0, clientPacket);
+
+            #endregion Client Sending Data
+
+            Thread.Sleep(2000);
+
+            Assert.IsTrue(serverReceivedPacket && clientReceivedPacket);
+        }
+    }
+}

--- a/NetSync/NetSync.sln
+++ b/NetSync/NetSync.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSync", "NetSync\NetSync.csproj", "{3BF7736C-7346-4041-A756-E88A084DFE04}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSync.UnitTests", "NetSync.UnitTests\NetSync.UnitTests.csproj", "{C2987348-1A0F-4F97-81E2-ACD81AF201C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{3BF7736C-7346-4041-A756-E88A084DFE04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BF7736C-7346-4041-A756-E88A084DFE04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BF7736C-7346-4041-A756-E88A084DFE04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2987348-1A0F-4F97-81E2-ACD81AF201C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2987348-1A0F-4F97-81E2-ACD81AF201C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2987348-1A0F-4F97-81E2-ACD81AF201C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2987348-1A0F-4F97-81E2-ACD81AF201C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NetSync/NetSync/Packets.cs
+++ b/NetSync/NetSync/Packets.cs
@@ -1,0 +1,18 @@
+﻿namespace NetSync
+{
+    internal enum Packets : byte
+    {
+        /// <summary>
+        /// Initial handshake packet.
+        /// </summary>
+        Handshake = 0,
+        /// <summary>
+        /// Used for telling the client that server has accepted/authorized the handshake.
+        /// </summary>
+        SuccessfulHandshake,
+        /// <summary>
+        /// Used for syncing classes/ objects over network. AKA Network Objects.
+        /// </summary>
+        SyncNetworkObject
+    }
+}

--- a/NetSync/NetSync/Server/Connection.cs
+++ b/NetSync/NetSync/Server/Connection.cs
@@ -1,4 +1,6 @@
-﻿namespace NetSync.Server
+﻿using System;
+
+namespace NetSync.Server
 {
     public class Connection
     {
@@ -9,7 +11,10 @@
         /// </summary>
         public string UAI;
         public bool IsConnected;
+        public bool HandshakeCompleted;
         public readonly NetworkServer ServerInstance;
+
+        internal object ConnectionLock = new object();
 
         public Connection(ushort id, NetworkServer serverInstance)
         {
@@ -23,8 +28,12 @@
         /// </summary>
         public void Disconnect()
         {
-            IsConnected = false;
-            ServerInstance.Transport.ServerDisconnect(this);
+            lock (ConnectionLock)
+            {
+                IsConnected = false;
+                HandshakeCompleted = false;
+                ServerInstance.Transport.ServerDisconnect(this);
+            }
         }
     }
 }

--- a/NetSync/NetSync/Server/Connection.cs
+++ b/NetSync/NetSync/Server/Connection.cs
@@ -9,18 +9,27 @@ namespace NetSync.Server
         /// In most cases this will be the connection ip.
         /// Stands for Unique Address Identifier
         /// </summary>
-        public string UAI;
-        public bool IsConnected;
-        public bool HandshakeCompleted;
-        public readonly NetworkServer ServerInstance;
+        internal string UAI;
+        internal bool IsConnected;
+        internal bool HandshakeCompleted;
+        private readonly NetworkServer _serverInstance;
 
         internal object ConnectionLock = new object();
 
         public Connection(ushort id, NetworkServer serverInstance)
         {
-            ServerInstance = serverInstance;
+            _serverInstance = serverInstance;
             IsConnected = false;
             ConnectionId = id;
+        }
+
+        /// <summary>
+        /// In most cases this will be the connection's remote end-point.
+        /// </summary>
+        /// <returns>Unique Address Identifier</returns>
+        public string GetUniqueAddress()
+        {
+            return UAI;
         }
 
         /// <summary>
@@ -32,7 +41,8 @@ namespace NetSync.Server
             {
                 IsConnected = false;
                 HandshakeCompleted = false;
-                ServerInstance.Transport.ServerDisconnect(this);
+                UAI = string.Empty;
+                _serverInstance.Transport.ServerDisconnect(this);
             }
         }
     }

--- a/NetSync/NetSync/Server/NetworkServer.cs
+++ b/NetSync/NetSync/Server/NetworkServer.cs
@@ -17,12 +17,17 @@ namespace NetSync.Server
         public Connection[] Connections;
 
         public delegate void MessageHandle(Connection connection, Packet packet);
+
         private Dictionary<PacketHeader, ServerHandle> ReceiveHandlers = new Dictionary<PacketHeader, ServerHandle>();
 
         /// <summary>
         /// Server side handler queue for single threaded applications.
         /// </summary>
         private List<ServerQueueHandle> _serverHandleQueue = new List<ServerQueueHandle>();
+
+        /// <summary>
+        /// The lock object that should be used for reading/modifying Server Handle Queue
+        /// </summary>
         internal object QueueLock = new object();
 
         /// <summary>
@@ -33,19 +38,40 @@ namespace NetSync.Server
         #region Events
 
         public delegate void NetworkServerStarted(NetworkServer server);
+        /// <summary>
+        /// Called after server started.
+        /// </summary>
         public event NetworkServerStarted OnServerStarted;
 
         public delegate void NetworkServerConnected(Connection connection);
+        /// <summary>
+        /// Called after server receives establishes a new connection with a client.
+        /// </summary>
         public event NetworkServerConnected OnServerConnected;
 
         public delegate void NetworkServerDisconnected(Connection connection);
+        /// <summary>
+        /// Called after server closes a connection with a client.
+        /// </summary>
         public event NetworkServerDisconnected OnServerDisconnected;
 
         public delegate void NetworkServerStopped(NetworkServer server);
+        /// <summary>
+        /// Called after server stops.
+        /// </summary>
         public event NetworkServerStopped OnServerStopped;
 
         public delegate void NetworkServerError(string description);
+        /// <summary>
+        /// Called after Server throws/detects an error.
+        /// </summary>
         public event NetworkServerError OnServerErrorDetected;
+
+        public delegate void NetworkServerSuccessfulHandshake(Connection connection);
+        /// <summary>
+        /// Called after server successfully finishes the handshake process with a client.
+        /// </summary>
+        public event NetworkServerSuccessfulHandshake OnServerHandshake;
 
         #endregion Events
 
@@ -71,6 +97,8 @@ namespace NetSync.Server
             {
                 Connections[i] = new Connection(i, this);
             }
+
+            RegisterHandler((byte)Packets.Handshake, ServerHandshakeReceived, 0);
         }
 
         /// <summary>
@@ -163,22 +191,51 @@ namespace NetSync.Server
 
         #endregion Network Send
 
-        #region Transport Events
+        #region Server Events
 
+        /// <summary>
+        /// When server gets started and begins listening for new connections.
+        /// </summary>
+        /// <param name="server">The NetworkServer that started.</param>
         private void ServerStarted(NetworkServer server)
         {
             IsActive = true;
             OnServerStarted?.Invoke(server);
         }
 
+        /// <summary>
+        /// When a new client joins the server.
+        /// </summary>
+        /// <param name="connection">Connection class this client is using/utilizing.</param>
         private void ServerConnected(Connection connection)
         {
             connection.IsConnected = true;
+            connection.HandshakeCompleted = false;
+
+            //Handling the handshake with client.
+            Packet handshakePacket = new Packet();
+            //Informing client regarding it's connection ID.
+            handshakePacket.WriteUnsignedShort(connection.ConnectionId);
+            NetworkSend(connection, (byte)Packets.Handshake, handshakePacket, 0);
+
             OnServerConnected?.Invoke(connection);
         }
 
+        /// <summary>
+        /// When Server received a data from a client.
+        /// </summary>
+        /// <param name="connection">Connection/Client who send the data.</param>
+        /// <param name="packet">Packet server received.</param>
+        /// <param name="packetHeader">NetSync Packet Header of the packet server received.</param>
         private void ServerDataReceived(Connection connection, Packet packet, PacketHeader packetHeader)
         {
+            //If the client did not complete the initial handshake and the packet they send is not a handshake packet refuse connection.
+            if (connection.HandshakeCompleted == false && packetHeader.Channel != 0 || packetHeader.PacketId != (byte)Packets.Handshake)
+            {
+                connection.Disconnect();
+                return;
+            }
+
             if (ReceiveHandlers[packetHeader].IsQueued)
             {
                 ServerQueueHandle queueHandle = new ServerQueueHandle(connection, packet, ReceiveHandlers[packetHeader]);
@@ -192,25 +249,37 @@ namespace NetSync.Server
             ReceiveHandlers[packetHeader].Handler(connection, packet);
         }
 
+        /// <summary>
+        /// When a client disconnects from server.
+        /// </summary>
+        /// <param name="connection">Connection/Client that disconnected from server.</param>
         private void ServerDisconnected(Connection connection)
         {
             connection.IsConnected = false;
             OnServerDisconnected?.Invoke(connection);
         }
 
+        /// <summary>
+        /// When server stops completely.
+        /// </summary>
+        /// <param name="server"></param>
         private void ServerStopped(NetworkServer server)
         {
             IsActive = false;
             OnServerStopped?.Invoke(server);
         }
 
+        /// <summary>
+        /// When server detects an error.
+        /// </summary>
+        /// <param name="description">Description of the error.</param>
         private void OnServerError(string description)
         {
             Console.WriteLine("Error: " + description);
             OnServerErrorDetected?.Invoke(description);
         }
 
-        #endregion Transport Events
+        #endregion Server Events
 
         /// <summary>
         /// Executes all the queued handlers. Useful for single threaded applications.
@@ -227,18 +296,43 @@ namespace NetSync.Server
             }
         }
 
+        private void ServerHandshakeReceived(Connection connection, Packet packet)
+        {
+            ushort connectionId = packet.ReadUnsignedShort();
+            //If client fails the handshake we will refuse the connection.
+            if (connection.ConnectionId == connectionId)
+            {
+                connection.HandshakeCompleted = true;
+
+                Packet handshakePacket = new Packet();
+                handshakePacket.WriteUnsignedShort(connectionId);
+
+                NetworkSend(connection, (byte)Packets.SuccessfulHandshake, handshakePacket, 0);
+                OnServerHandshake?.Invoke(connection);
+
+                LateComerNetworkObjectSync(connection);
+            }
+            else
+                connection.Disconnect();
+        }
+
         #region Network Object Handling
 
         /// <summary>
         /// Creates a networked object for everyone
         /// </summary>
         /// <param name="objectToCreate">What class/object to create on all clients</param>
-        public void CreateNetworkObject(object objectToCreate)
+        /// <param name="lateJoinerSynced">Will this object also get created for late comers</param>
+        public void CreateNetworkObject(object objectToCreate, bool lateJoinerSynced = false)
         {
             string typeName = objectToCreate.GetType().AssemblyQualifiedName;
             Packet packet = new Packet();
             packet.WriteString(typeName);
-            NetworkSendEveryone(1, packet);
+            NetworkSendEveryone((byte)Packets.SyncNetworkObject, packet, 0);
+
+            //Adding the object to the NetworkObjects list for late comer synchronization
+            if (lateJoinerSynced && !NetworkedObjects.Contains(objectToCreate))
+                NetworkedObjects.Add(objectToCreate);
         }
 
         /// <summary>
@@ -246,12 +340,49 @@ namespace NetSync.Server
         /// </summary>
         /// <param name="connection">Client's connection</param>
         /// <param name="objectToCreate">Which networked object/class to create</param>
-        public void CreateNetworkObjectForClient(Connection connection, object objectToCreate)
+        /// <param name="lateJoinerSynced">Will this object also get created for late comers</param>
+        public void CreateNetworkObject(Connection connection, object objectToCreate, bool lateJoinerSynced = false)
         {
             string typeName = objectToCreate.GetType().AssemblyQualifiedName;
             Packet packet = new Packet();
             packet.WriteString(typeName);
-            NetworkSend(connection, 1, packet);
+            NetworkSend(connection, (byte)Packets.SyncNetworkObject, packet, 0);
+
+            //Adding the object to the NetworkObjects list for late comer synchronization
+            if (lateJoinerSynced && !NetworkedObjects.Contains(objectToCreate))
+                NetworkedObjects.Add(objectToCreate);
+        }
+
+        /// <summary>
+        /// Synchronizes the already registered network objects for the late comer.
+        /// </summary>
+        /// <param name="connection">Late comer client</param>
+        private void LateComerNetworkObjectSync(Connection connection)
+        {
+            //If there is any NetworkObjects in the list create them as well for the new client(late joiner).
+            if (NetworkedObjects.Count > 0)
+            {
+                foreach (var networkedObject in NetworkedObjects)
+                {
+                    CreateNetworkObject(connection, networkedObject);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a networked object from NetworkObjects list(late comer synced).
+        /// </summary>
+        /// <param name="objectToRemove">Object/Class to remove.</param>
+        public void RemoveNetworkObject(object objectToRemove)
+        {
+            if (NetworkedObjects.Contains(objectToRemove))
+            {
+                Console.WriteLine("Removed");
+                NetworkedObjects.Remove(objectToRemove);
+                return;
+            }
+
+            OnServerError("Network Object: Can't remove a non-registered object!");
         }
 
         #endregion Network Object Handling

--- a/NetSync/NetSync/Transport/AsyncTcp/AsyncTcp.cs
+++ b/NetSync/NetSync/Transport/AsyncTcp/AsyncTcp.cs
@@ -4,9 +4,9 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 
-namespace NetSync.Transport.SyncTcp
+namespace NetSync.Transport.AsyncTcp
 {
-    public class SyncTcp : TransportBase
+    public class AsyncTcp : TransportBase
     {
         private TcpClient _tcpClient;
         private TcpListener _tcpListener;
@@ -129,9 +129,8 @@ namespace NetSync.Transport.SyncTcp
             {
                 if (connection.IsConnected) continue;
 
-                ushort connectionId = connection.ConnectionId;
+                _serverConnections[connection.ConnectionId] = new ServerConnection(tcpClient, _bufferSize, this, connection);
                 connection.UAI = tcpClient.Client.RemoteEndPoint.ToString();
-                _serverConnections[connectionId] = new ServerConnection(tcpClient, _bufferSize, this, connection);
                 OnServerConnect(connection);
                 break;
             }
@@ -140,9 +139,7 @@ namespace NetSync.Transport.SyncTcp
         public override void ServerDisconnect(Connection connection)
         {
             if (_serverConnections[connection.ConnectionId] == null) return;
-
             _serverConnections[connection.ConnectionId].Disconnect();
-            connection.IsConnected = false;
             _serverConnections[connection.ConnectionId] = null;
             OnServerDisconnect(connection);
         }
@@ -173,9 +170,9 @@ namespace NetSync.Transport.SyncTcp
             private byte[] _receiveBuffer;
 
             private Connection _connection;
-            private SyncTcp _syncTcp;
+            private AsyncTcp _syncTcp;
 
-            internal ServerConnection(TcpClient tcpClient, int bufferSize, SyncTcp syncTcp, Connection connection)
+            internal ServerConnection(TcpClient tcpClient, int bufferSize, AsyncTcp syncTcp, Connection connection)
             {
                 _syncTcp = syncTcp;
                 _connection = connection;
@@ -226,7 +223,6 @@ namespace NetSync.Transport.SyncTcp
             {
                 try
                 {
-
                     byte[] data = packet.GetByteArray();
                     _netStream.BeginWrite(data, 0, data.Length, null, null);
                 }
@@ -240,10 +236,17 @@ namespace NetSync.Transport.SyncTcp
 
             internal void Disconnect()
             {
+                _tcpClient?.Client?.Disconnect(true);
                 _tcpClient?.Close();
                 _receiveBuffer = null;
                 _tcpClient = null;
                 _netStream = null;
+
+                lock (_connection.ConnectionLock)
+                {
+                    _connection.IsConnected = false;
+                    _connection.HandshakeCompleted = false;
+                }
             }
         }
 

--- a/NetSync/NetSync/Transport/AsyncTcp/AsyncTcp.cs
+++ b/NetSync/NetSync/Transport/AsyncTcp/AsyncTcp.cs
@@ -94,11 +94,10 @@ namespace NetSync.Transport.AsyncTcp
 
         public override void ClientDisconnect()
         {
-            _tcpClient.Client?.Disconnect(true);
             _tcpClient?.Close();
-            _tcpClient = null;
-            _netStream = null;
             _receiveBuffer = null;
+            _netStream = null;
+            _tcpClient = null;
             OnClientDisconnect();
         }
 


### PR DESCRIPTION
These changes should be the last major changes in library. After hitting the 1.0 mark this type of major changes should be kept to a minimum.
<br>
### Renamed SynTcp Transport To AsyncTcp
SyncTcp naming was creating some confusion in people's head. I have renamed the SyncTcp to AsyncTcp to reflect it's functionality.

### Increased Summaries/Comments Across The Entire Library
As I am closing on 1.0 release it is utmost important to summarize everything as much as possible. It is a good practice for any open-source project.

### Network Objects Can Now Be Synced For Late Comers
You can now mark your Network Object to be registered in memory and in case of any late joiners into the network after  creation of a Network Object; it will get created on that late joiner client as well.
This feature implementation also requires a functionality for removing Network Objects from latecomer synchronization as well so... Yeah. I did that too. Hurray! 👍 

### Handshake Security
If the client tries to send a data to the server before completing the initial handshake process; Server will refuse that connection. This is a small but useful security feature. Nothing major though. 🔒 

### Enum For Built-In Handlers
It is hard to remember all packet/handler Id's. It is a good practice to create an enum to store all packets in and use accordingly from there. This is the suggested way of development but you are free to go however you want. This is what I am using for NetSync's built-in networked functionalities.