### PR TITLE
Made nagle's algorithm optional for AsyncTcp

### DIFF
--- a/NetSync/NetSync.sln.DotSettings
+++ b/NetSync/NetSync.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nagle/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
When constructing AsyncTcp now developer can specify whether they want to use the Nagle's algorithm or not.